### PR TITLE
Block click-through

### DIFF
--- a/src/features/ClickBlockPatch.cs
+++ b/src/features/ClickBlockPatch.cs
@@ -13,6 +13,8 @@ namespace HydraMenu.features
 			MainUI ui = MainUI.Instance;
 			if(ui == null || !ui.visible) return true;
 
+			if(GUIUtility.hotControl != 0) return true;
+
 			Vector2 mousePos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
 			bool inMenu = mousePos.x >= MainUI.windowPosition.x && mousePos.x <= (MainUI.windowPosition.x + MainUI.WindowSize.x) && mousePos.y >= MainUI.windowPosition.y && mousePos.y <= (MainUI.windowPosition.y + MainUI.WindowSize.y);
 			return !inMenu;
@@ -27,4 +29,7 @@ namespace HydraMenu.features
 
 	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveClickUp))]
 	static class BlockPassiveButtonClickUp { static bool Prefix() => ClickBlock.ShouldBlock(); }
+
+	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.SetPassiveButtonHoverStateActive))]
+	static class BlockHoverActive { static bool Prefix() => ClickBlock.ShouldBlock(); }
 }

--- a/src/features/ClickBlockPatch.cs
+++ b/src/features/ClickBlockPatch.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using HydraMenu.ui;
+using HydraMenu.ui.sections;
+using UnityEngine;
+
+namespace HydraMenu.features
+{
+	static class ClickBlock
+	{
+		public static bool ShouldBlock()
+		{
+			if(!MenuSection.BlockClickThrough) return true;
+			MainUI ui = MainUI.Instance;
+			if(ui == null || !ui.visible) return true;
+
+			Vector2 mousePos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
+			bool inMenu = mousePos.x >= MainUI.windowPosition.x && mousePos.x <= (MainUI.windowPosition.x + MainUI.WindowSize.x) && mousePos.y >= MainUI.windowPosition.y && mousePos.y <= (MainUI.windowPosition.y + MainUI.WindowSize.y);
+			return !inMenu;
+		}
+	}
+
+	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveClickDown))]
+	static class BlockPassiveButtonClickDown { static bool Prefix() => ClickBlock.ShouldBlock(); }
+
+	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveRepeatDown))]
+	static class BlockPassiveButtonRepeatDown { static bool Prefix() => ClickBlock.ShouldBlock(); }
+
+	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveClickUp))]
+	static class BlockPassiveButtonClickUp { static bool Prefix() => ClickBlock.ShouldBlock(); }
+}

--- a/src/features/ClickBlockPatch.cs
+++ b/src/features/ClickBlockPatch.cs
@@ -7,7 +7,7 @@ namespace HydraMenu.features
 {
 	static class ClickBlock
 	{
-		public static bool ShouldBlock()
+		public static bool BlockMenuClicks()
 		{
 			if(!MenuSection.BlockClickThrough) return true;
 			MainUI ui = MainUI.Instance;
@@ -22,14 +22,14 @@ namespace HydraMenu.features
 	}
 
 	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveClickDown))]
-	static class BlockPassiveButtonClickDown { static bool Prefix() => ClickBlock.ShouldBlock(); }
+	static class BlockPassiveButtonClickDown { static bool Prefix() => ClickBlock.BlockMenuClicks(); }
 
 	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveRepeatDown))]
-	static class BlockPassiveButtonRepeatDown { static bool Prefix() => ClickBlock.ShouldBlock(); }
+	static class BlockPassiveButtonRepeatDown { static bool Prefix() => ClickBlock.BlockMenuClicks(); }
 
 	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.ReceiveClickUp))]
-	static class BlockPassiveButtonClickUp { static bool Prefix() => ClickBlock.ShouldBlock(); }
+	static class BlockPassiveButtonClickUp { static bool Prefix() => ClickBlock.BlockMenuClicks(); }
 
 	[HarmonyPatch(typeof(PassiveButton), nameof(PassiveButton.SetPassiveButtonHoverStateActive))]
-	static class BlockHoverActive { static bool Prefix() => ClickBlock.ShouldBlock(); }
+	static class BlockHoverActive { static bool Prefix() => ClickBlock.BlockMenuClicks(); }
 }

--- a/src/ui/MainUI.cs
+++ b/src/ui/MainUI.cs
@@ -7,6 +7,13 @@ namespace HydraMenu.ui
 	public class MainUI : MonoBehaviour
 	{
 		// Current window
+		public static MainUI Instance;
+
+		private void Awake()
+		{
+			Instance = this;
+		}
+
 		public bool visible = false;
 		public static float scale = 1.0f;
 
@@ -93,20 +100,15 @@ namespace HydraMenu.ui
 
 				sections[activeTab].HandleSubsectionMove(offset);
 			}
-
-			BlockClickThrough();
 		}
 
-		private void BlockClickThrough()
+		private bool IsInHeader(Vector2 mousePos)
 		{
-			if(!MenuSection.BlockClickThrough) return;
-
-			Vector2 mousePos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
-
-			if(IsInBox(mousePos) && (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1) || Input.GetMouseButtonDown(2)))
-			{
-				Input.ResetInputAxes();
-			}
+			return
+				mousePos.x >= windowPosition.x &&
+				mousePos.x <= (windowPosition.x + WindowSize.x) &&
+				mousePos.y >= windowPosition.y &&
+				mousePos.y <= (windowPosition.y + HeaderSize.y);
 		}
 
 		public void OnGUI()
@@ -140,17 +142,6 @@ namespace HydraMenu.ui
 				}
 			}
 
-			if(MenuSection.BlockClickThrough && IsInBox(Event.current.mousePosition))
-			{
-				switch(Event.current.type)
-				{
-					case EventType.MouseDown:
-					case EventType.MouseUp:
-					case EventType.ScrollWheel:
-						Event.current.Use();
-						break;
-				}
-			}
 		}
 
 		private void HandleBoxMovement()
@@ -164,7 +155,7 @@ namespace HydraMenu.ui
 				// I tried using currentEvent.delta to get the delta between the last mouse position and the current one,
 				// however I noticed it would 'skip' quite frequently resulting in the window box not properly lining up where it should actually be dragged
 				case EventType.MouseDown:
-					if(!IsInBox(mousePos)) break;
+					if(!IsInHeader(mousePos)) break;
 
 					isDragging = true;
 					mouseDelta = currentEvent.mousePosition - windowPosition;
@@ -181,15 +172,6 @@ namespace HydraMenu.ui
 					isDragging = false;
 					break;
 			}
-		}
-
-		private bool IsInBox(Vector2 mousePos)
-		{
-			return
-				mousePos.x >= windowPosition.x &&
-				mousePos.x <= (windowPosition.x + WindowSize.x) &&
-				mousePos.y >= windowPosition.y &&
-				mousePos.y <= (windowPosition.y + WindowSize.y);
 		}
 
 		private void RenderTab(byte position, ISection section)

--- a/src/ui/MainUI.cs
+++ b/src/ui/MainUI.cs
@@ -94,7 +94,19 @@ namespace HydraMenu.ui
 				sections[activeTab].HandleSubsectionMove(offset);
 			}
 
-			HandleBoxMovement();
+			BlockClickThrough();
+		}
+
+		private void BlockClickThrough()
+		{
+			if(!MenuSection.BlockClickThrough) return;
+
+			Vector2 mousePos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
+
+			if(IsInBox(mousePos) && (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1) || Input.GetMouseButtonDown(2)))
+			{
+				Input.ResetInputAxes();
+			}
 		}
 
 		public void OnGUI()
@@ -103,6 +115,8 @@ namespace HydraMenu.ui
 			if(!visible) return;
 
 			GUI.skin.label.fontSize = (int)(13 * scale);
+
+			HandleBoxMovement();
 
 			// Render UI box
 			GUI.Box(new Rect(windowPosition.x, windowPosition.y, WindowSize.x, WindowSize.y), $"{MyPluginInfo.PLUGIN_NAME} - {MyPluginInfo.PLUGIN_VERSION}", Styles.MainBox);
@@ -123,6 +137,18 @@ namespace HydraMenu.ui
 
 					GUILayout.EndScrollView();
 					GUILayout.EndArea();
+				}
+			}
+
+			if(MenuSection.BlockClickThrough && IsInBox(Event.current.mousePosition))
+			{
+				switch(Event.current.type)
+				{
+					case EventType.MouseDown:
+					case EventType.MouseUp:
+					case EventType.ScrollWheel:
+						Event.current.Use();
+						break;
 				}
 			}
 		}

--- a/src/ui/MainUI.cs
+++ b/src/ui/MainUI.cs
@@ -102,13 +102,13 @@ namespace HydraMenu.ui
 			}
 		}
 
-		private bool IsInHeader(Vector2 mousePos)
+		private bool IsInBox(Vector2 mousePos)
 		{
 			return
 				mousePos.x >= windowPosition.x &&
 				mousePos.x <= (windowPosition.x + WindowSize.x) &&
 				mousePos.y >= windowPosition.y &&
-				mousePos.y <= (windowPosition.y + HeaderSize.y);
+				mousePos.y <= (windowPosition.y + WindowSize.y);
 		}
 
 		public void OnGUI()
@@ -155,7 +155,7 @@ namespace HydraMenu.ui
 				// I tried using currentEvent.delta to get the delta between the last mouse position and the current one,
 				// however I noticed it would 'skip' quite frequently resulting in the window box not properly lining up where it should actually be dragged
 				case EventType.MouseDown:
-					if(!IsInHeader(mousePos)) break;
+					if(!IsInBox(mousePos)) break;
 
 					isDragging = true;
 					mouseDelta = currentEvent.mousePosition - windowPosition;

--- a/src/ui/MainUI.cs
+++ b/src/ui/MainUI.cs
@@ -162,8 +162,7 @@ namespace HydraMenu.ui
 					break;
 
 				case EventType.MouseDrag:
-					if(!isDragging) break;
-
+				if(!isDragging || GUIUtility.hotControl != 0) break;
 					windowPosition.x = mousePos.x - mouseDelta.x;
 					windowPosition.y = mousePos.y - mouseDelta.y;
 					break;

--- a/src/ui/sections/MenuSection.cs
+++ b/src/ui/sections/MenuSection.cs
@@ -5,11 +5,14 @@ namespace HydraMenu.ui.sections
 {
 	internal class MenuSection : ISection
 	{
+		public static bool BlockClickThrough = true;
+
 		public MenuSection() : base("Menu") { }
 
 		public override void Render()
 		{
 			// GUILayout.Label($"Texture 2D memory usage: {Texture2D.currentTextureMemory}");
+			BlockClickThrough = GUILayout.Toggle(BlockClickThrough, "Block Click-Through");
 			Hydra.notifications.DisableNotifications = GUILayout.Toggle(Hydra.notifications.DisableNotifications, "Disable Notifications");
 
 			GUILayout.Label($"Primary Color: {Styles.primaryColor}");


### PR DESCRIPTION
something minor this time. This adds a "block click through" toggle to `MenuSection` (default true). Enabling this will prevent clicks/hover from interacting with the game ui if they are inside the menu border.